### PR TITLE
EUI-ify the empty prompt view

### DIFF
--- a/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_button/create_button.js
+++ b/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_button/create_button.js
@@ -88,8 +88,8 @@ export class CreateButton extends Component {
         <EuiButton
           data-test-subj="createIndexPatternButton"
           fill={true}
-          size={'s'}
           onClick={options[0].onClick}
+          iconType="plusInCircle"
         >
           {children}
         </EuiButton>

--- a/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_prompt/index.js
+++ b/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/create_index_pattern_prompt/index.js
@@ -20,11 +20,12 @@
 import React, { Fragment } from 'react';
 import {
   EuiEmptyPrompt,
-  EuiIcon,
   EuiText,
   EuiHorizontalRule,
-  EuiFlexGroup,
-  EuiFlexItem,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+  EuiPageContent,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { CreateButton } from '../create_button';
@@ -32,76 +33,76 @@ import { CreateButton } from '../create_button';
 export const CreateIndexPatternPrompt = ({
   indexPatternCreationOptions
 }) => (
-  <EuiEmptyPrompt
-    className="euiPanel"
-    iconType="indexPatternApp"
-    title={
-      <EuiText grow={false}>
-        <h2>
-          <FormattedMessage id="kbn.management.indexPatternPrompt.title" defaultMessage="Create your first index pattern" />
-        </h2>
-      </EuiText>}
-    body={
-      <Fragment>
-        <p style={{ padding: '0 24px' }}>
-          <FormattedMessage
-            id="kbn.management.indexPatternPrompt.subtitle"
-            defaultMessage="Index patterns allow you to bucket disparate data sources together so their shared fields may be queried in
-              Kibana."
-          />
-        </p>
-        <EuiHorizontalRule margin="m" />
-        <p style={{ textAlign: 'left' }}>
-          <FormattedMessage
-            id="kbn.management.indexPatternPrompt.examplesTitle"
-            defaultMessage="Examples of index patterns"
-          />
-        </p>
-        <div style={{ textAlign: 'left' }}>
-          <EuiFlexGroup>
-            <EuiFlexItem className="indexPatternPromptListItem">
-              <EuiIcon type="document"/>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+  <EuiPageContent horizontalPosition="center">
+    <EuiEmptyPrompt
+      iconType="indexPatternApp"
+      title={
+        <EuiText grow={false}>
+          <h2>
+            <FormattedMessage id="kbn.management.indexPatternPrompt.title" defaultMessage="Create your first index pattern" />
+          </h2>
+        </EuiText>}
+      body={
+        <Fragment>
+          <p>
+            <FormattedMessage
+              id="kbn.management.indexPatternPrompt.subtitle"
+              defaultMessage="Index patterns allow you to bucket disparate data sources together so their shared fields may be queried in
+                Kibana."
+            />
+          </p>
+          <EuiHorizontalRule margin="l" />
+          <EuiText textAlign="left">
+            <p>
+              <FormattedMessage
+                id="kbn.management.indexPatternPrompt.examplesTitle"
+                defaultMessage="Examples of index patterns"
+              />
+            </p>
+          </EuiText>
+          <EuiDescriptionList className="indexPatternListPrompt__descList">
+            <EuiDescriptionListTitle>
+              Single data source
+            </EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
               <FormattedMessage
                 id="kbn.management.indexPatternPrompt.exampleOne"
                 defaultMessage="Index a single data source named log-west-001 so you can build charts or query its contents fast."
               />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiFlexGroup>
-            <EuiFlexItem className="indexPatternPromptListItem">
-              <EuiIcon type="copy"/>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>
+              Multiple data sources
+            </EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
               <FormattedMessage
                 id="kbn.management.indexPatternPrompt.exampleTwo"
                 defaultMessage="Group all incoming data sources starting with log-west* so you can query against all your west coast server
                   logs."
               />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiFlexGroup>
-            <EuiFlexItem className="indexPatternPromptListItem">
-              <EuiIcon type="calendar"/>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>
+              Custom groupings
+            </EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
               <FormattedMessage
                 id="kbn.management.indexPatternPrompt.exampleThree"
                 defaultMessage="Specifically group your archived, monthly, roll-up metrics of those logs into a separate index pattern so
                   you can aggregate histotical trends to compare."
               />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        </div>
-      </Fragment>
-    }
-    actions={[
-      <CreateButton options={indexPatternCreationOptions}>
-        <FormattedMessage
-          id="kbn.management.indexPatternPrompt.createBtn"
-          defaultMessage="Create index pattern"
-        />
-      </CreateButton>
-    ]}
-  />);
+            </EuiDescriptionListDescription>
+          </EuiDescriptionList>
+        </Fragment>
+      }
+      actions={[
+        <CreateButton options={indexPatternCreationOptions}>
+          <FormattedMessage
+            id="kbn.management.indexPatternPrompt.createBtn"
+            defaultMessage="Create index pattern"
+          />
+        </CreateButton>
+      ]}
+    />
+  </EuiPageContent>
+);

--- a/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/index.scss
+++ b/src/legacy/core_plugins/kibana/public/management/sections/index_patterns/index.scss
@@ -1,4 +1,6 @@
 #indexPatternListReact {
+  display: flex;
+  
   .indexPatternList__headerWrapper {
     padding-bottom: $euiSizeS;
   }
@@ -13,7 +15,7 @@
     }
   }
 
-  .indexPatternPromptListItem {
-    padding-top: 4px;
+  .indexPatternListPrompt__descList {
+    text-align: left;
   }
 }


### PR DESCRIPTION
Swaps out some parts for EUI components making the Index Pattern empty prompt more consistent with empty prompts on sibling Management views.

<img width="971" alt="screenshot 2019-02-06 11 54 13" src="https://user-images.githubusercontent.com/446285/52362339-fb402980-2a05-11e9-91a0-56d84fcc347d.png">
