### PR TITLE
Reactification of management/section/settings, Fix updating config prop

### DIFF
--- a/src/legacy/core_plugins/kibana/public/management/sections/settings/advanced_settings.test.tsx
+++ b/src/legacy/core_plugins/kibana/public/management/sections/settings/advanced_settings.test.tsx
@@ -27,8 +27,11 @@ import {
   UiSettingsType,
 } from '../../../../../../../core/server/';
 import { FieldSetting } from './types';
-
 import { AdvancedSettings } from './advanced_settings';
+
+jest.mock('ui/new_platform', () => ({
+  npStart: mockConfig(),
+}));
 
 jest.mock('./components/field', () => ({
   Field: () => {
@@ -48,178 +51,183 @@ jest.mock('./components/search', () => ({
   },
 }));
 
-const defaultConfig: Partial<FieldSetting> = {
-  displayName: 'defaultName',
-  requiresPageReload: false,
-  isOverridden: false,
-  ariaName: 'ariaName',
-  readOnly: false,
-  isCustom: false,
-  defVal: 'defVal',
-  type: 'string' as UiSettingsType,
-  category: ['category'],
-};
+function mockConfig() {
+  const defaultConfig: Partial<FieldSetting> = {
+    displayName: 'defaultName',
+    requiresPageReload: false,
+    isOverridden: false,
+    ariaName: 'ariaName',
+    readOnly: false,
+    isCustom: false,
+    defVal: 'defVal',
+    type: 'string' as UiSettingsType,
+    category: ['category'],
+  };
 
-const config = {
-  set: (key: string, value: any) => Promise.resolve(true),
-  remove: (key: string) => Promise.resolve(true),
-  isCustom: (key: string) => false,
-  isOverridden: (key: string) => Boolean(config.getAll()[key].isOverridden),
-  getRegistered: () => ({} as Readonly<Record<string, UiSettingsParams>>),
-  overrideLocalDefault: (key: string, value: any) => {},
-  getUpdate$: () =>
-    new Observable<{
-      key: string;
-      newValue: any;
-      oldValue: any;
-    }>(),
-  isDeclared: (key: string) => true,
-  isDefault: (key: string) => true,
+  const config = {
+    set: (key: string, value: any) => Promise.resolve(true),
+    remove: (key: string) => Promise.resolve(true),
+    isCustom: (key: string) => false,
+    isOverridden: (key: string) => Boolean(config.getAll()[key].isOverridden),
+    getRegistered: () => ({} as Readonly<Record<string, UiSettingsParams>>),
+    overrideLocalDefault: (key: string, value: any) => {},
+    getUpdate$: () =>
+      new Observable<{
+        key: string;
+        newValue: any;
+        oldValue: any;
+      }>(),
+    isDeclared: (key: string) => true,
+    isDefault: (key: string) => true,
 
-  getSaved$: () =>
-    new Observable<{
-      key: string;
-      newValue: any;
-      oldValue: any;
-    }>(),
+    getSaved$: () =>
+      new Observable<{
+        key: string;
+        newValue: any;
+        oldValue: any;
+      }>(),
 
-  getUpdateErrors$: () => new Observable<Error>(),
-  get: (key: string, defaultOverride?: any): any => config.getAll()[key] || defaultOverride,
-  get$: (key: string) => new Observable<any>(config.get(key)),
-  getAll: (): Readonly<Record<string, UiSettingsParams & UserProvidedValues>> => {
-    return {
-      'test:array:setting': {
-        ...defaultConfig,
-        value: ['default_value'],
-        name: 'Test array setting',
-        description: 'Description for Test array setting',
-        category: ['elasticsearch'],
-      },
-      'test:boolean:setting': {
-        ...defaultConfig,
-        value: true,
-        name: 'Test boolean setting',
-        description: 'Description for Test boolean setting',
-        category: ['elasticsearch'],
-      },
-      'test:image:setting': {
-        ...defaultConfig,
-        value: null,
-        name: 'Test image setting',
-        description: 'Description for Test image setting',
-        type: 'image',
-      },
-      'test:json:setting': {
-        ...defaultConfig,
-        value: '{"foo": "bar"}',
-        name: 'Test json setting',
-        description: 'Description for Test json setting',
-        type: 'json',
-      },
-      'test:markdown:setting': {
-        ...defaultConfig,
-        value: '',
-        name: 'Test markdown setting',
-        description: 'Description for Test markdown setting',
-        type: 'markdown',
-      },
-      'test:number:setting': {
-        ...defaultConfig,
-        value: 5,
-        name: 'Test number setting',
-        description: 'Description for Test number setting',
-      },
-      'test:select:setting': {
-        ...defaultConfig,
-        value: 'orange',
-        name: 'Test select setting',
-        description: 'Description for Test select setting',
-        type: 'select',
-        options: ['apple', 'orange', 'banana'],
-      },
-      'test:string:setting': {
-        ...defaultConfig,
-        ...{
-          value: null,
-          name: 'Test string setting',
-          description: 'Description for Test string setting',
-          type: 'string',
-          isCustom: true,
+    getUpdateErrors$: () => new Observable<Error>(),
+    get: (key: string, defaultOverride?: any): any => config.getAll()[key] || defaultOverride,
+    get$: (key: string) => new Observable<any>(config.get(key)),
+    getAll: (): Readonly<Record<string, UiSettingsParams & UserProvidedValues>> => {
+      return {
+        'test:array:setting': {
+          ...defaultConfig,
+          value: ['default_value'],
+          name: 'Test array setting',
+          description: 'Description for Test array setting',
+          category: ['elasticsearch'],
         },
-      },
-      'test:readonlystring:setting': {
-        ...defaultConfig,
-        ...{
-          value: null,
-          name: 'Test readonly string setting',
-          description: 'Description for Test readonly string setting',
-          type: 'string',
-          readOnly: true,
+        'test:boolean:setting': {
+          ...defaultConfig,
+          value: true,
+          name: 'Test boolean setting',
+          description: 'Description for Test boolean setting',
+          category: ['elasticsearch'],
         },
-      },
-      'test:customstring:setting': {
-        ...defaultConfig,
-        ...{
+        'test:image:setting': {
+          ...defaultConfig,
           value: null,
-          name: 'Test custom string setting',
-          description: 'Description for Test custom string setting',
-          type: 'string',
-          isCustom: true,
+          name: 'Test image setting',
+          description: 'Description for Test image setting',
+          type: 'image',
         },
-      },
-      'test:isOverridden:string': {
-        ...defaultConfig,
-        isOverridden: true,
-        value: 'foo',
-        name: 'An overridden string',
-        description: 'Description for overridden string',
-        type: 'string',
-      },
-      'test:isOverridden:number': {
-        ...defaultConfig,
-        isOverridden: true,
-        value: 1234,
-        name: 'An overridden number',
-        description: 'Description for overridden number',
-        type: 'number',
-      },
-      'test:isOverridden:json': {
-        ...defaultConfig,
-        isOverridden: true,
-        value: dedent`
-          {
-            "foo": "bar"
-          }
-        `,
-        name: 'An overridden json',
-        description: 'Description for overridden json',
-        type: 'json',
-      },
-      'test:isOverridden:select': {
-        ...defaultConfig,
-        isOverridden: true,
-        value: 'orange',
-        name: 'Test overridden select setting',
-        description: 'Description for overridden select setting',
-        type: 'select',
-        options: ['apple', 'orange', 'banana'],
-      },
-    };
-  },
-};
+        'test:json:setting': {
+          ...defaultConfig,
+          value: '{"foo": "bar"}',
+          name: 'Test json setting',
+          description: 'Description for Test json setting',
+          type: 'json',
+        },
+        'test:markdown:setting': {
+          ...defaultConfig,
+          value: '',
+          name: 'Test markdown setting',
+          description: 'Description for Test markdown setting',
+          type: 'markdown',
+        },
+        'test:number:setting': {
+          ...defaultConfig,
+          value: 5,
+          name: 'Test number setting',
+          description: 'Description for Test number setting',
+        },
+        'test:select:setting': {
+          ...defaultConfig,
+          value: 'orange',
+          name: 'Test select setting',
+          description: 'Description for Test select setting',
+          type: 'select',
+          options: ['apple', 'orange', 'banana'],
+        },
+        'test:string:setting': {
+          ...defaultConfig,
+          ...{
+            value: null,
+            name: 'Test string setting',
+            description: 'Description for Test string setting',
+            type: 'string',
+            isCustom: true,
+          },
+        },
+        'test:readonlystring:setting': {
+          ...defaultConfig,
+          ...{
+            value: null,
+            name: 'Test readonly string setting',
+            description: 'Description for Test readonly string setting',
+            type: 'string',
+            readOnly: true,
+          },
+        },
+        'test:customstring:setting': {
+          ...defaultConfig,
+          ...{
+            value: null,
+            name: 'Test custom string setting',
+            description: 'Description for Test custom string setting',
+            type: 'string',
+            isCustom: true,
+          },
+        },
+        'test:isOverridden:string': {
+          ...defaultConfig,
+          isOverridden: true,
+          value: 'foo',
+          name: 'An overridden string',
+          description: 'Description for overridden string',
+          type: 'string',
+        },
+        'test:isOverridden:number': {
+          ...defaultConfig,
+          isOverridden: true,
+          value: 1234,
+          name: 'An overridden number',
+          description: 'Description for overridden number',
+          type: 'number',
+        },
+        'test:isOverridden:json': {
+          ...defaultConfig,
+          isOverridden: true,
+          value: dedent`
+            {
+              "foo": "bar"
+            }
+          `,
+          name: 'An overridden json',
+          description: 'Description for overridden json',
+          type: 'json',
+        },
+        'test:isOverridden:select': {
+          ...defaultConfig,
+          isOverridden: true,
+          value: 'orange',
+          name: 'Test overridden select setting',
+          description: 'Description for overridden select setting',
+          type: 'select',
+          options: ['apple', 'orange', 'banana'],
+        },
+      };
+    },
+  };
+  return {
+    core: {
+      uiSettings: config,
+    },
+  };
+}
 
 describe('AdvancedSettings', () => {
   it('should render specific setting if given setting key', async () => {
-    const component = shallow(
-      <AdvancedSettings config={config} query="test:string:setting" enableSaving={true} />
-    );
+    const component = shallow(<AdvancedSettings query="test:string:setting" enableSaving={true} />);
 
     expect(component).toMatchSnapshot();
   });
 
   it('should render read-only when saving is disabled', async () => {
     const component = shallow(
-      <AdvancedSettings config={config} query="test:string:setting" enableSaving={false} />
+      <AdvancedSettings query="test:string:setting" enableSaving={false} />
     );
 
     expect(component).toMatchSnapshot();

--- a/src/legacy/core_plugins/kibana/public/management/sections/settings/components/field/field.tsx
+++ b/src/legacy/core_plugins/kibana/public/management/sections/settings/components/field/field.tsx
@@ -393,9 +393,6 @@ export class Field extends PureComponent<FieldProps, FieldState> {
       if (changeImage) {
         this.cancelChangeImage();
       }
-      this.setState({
-        savedValue: valueToSave,
-      });
     } catch (e) {
       toastNotifications.addDanger(
         i18n.translate('kbn.management.settings.field.saveFieldErrorMessage', {

--- a/src/legacy/core_plugins/kibana/public/management/sections/settings/index.html
+++ b/src/legacy/core_plugins/kibana/public/management/sections/settings/index.html
@@ -1,5 +1,5 @@
 <kbn-management-app section="kibana/settings">
   <kbn-management-advanced>
-    <div id="reactAdvancedSettings"></div>
+    <kbn-management-advanced-react route="route"></kbn-management-advanced-react>
   </kbn-management-advanced>
 </kbn-management-app>

--- a/src/legacy/core_plugins/kibana/public/management/sections/settings/index.js
+++ b/src/legacy/core_plugins/kibana/public/management/sections/settings/index.js
@@ -29,38 +29,10 @@ import {
 } from 'ui/registry/feature_catalogue';
 
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
 import { AdvancedSettings } from './advanced_settings';
 import { i18n } from '@kbn/i18n';
 import { getBreadcrumbs } from './breadcrumbs';
-import { npStart } from 'ui/new_platform';
-
-const REACT_ADVANCED_SETTINGS_DOM_ELEMENT_ID = 'reactAdvancedSettings';
-
-function updateAdvancedSettings($scope, config, query) {
-  $scope.$$postDigest(() => {
-    const node = document.getElementById(REACT_ADVANCED_SETTINGS_DOM_ELEMENT_ID);
-    if (!node) {
-      return;
-    }
-
-    render(
-      <I18nContext>
-        <AdvancedSettings
-          config={config}
-          query={query}
-          enableSaving={capabilities.get().advancedSettings.save}
-        />
-      </I18nContext>,
-      node
-    );
-  });
-}
-
-function destroyAdvancedSettings() {
-  const node = document.getElementById(REACT_ADVANCED_SETTINGS_DOM_ELEMENT_ID);
-  node && unmountComponentAtNode(node);
-}
+import { useEffectOnce } from 'react-use';
 
 uiRoutes.when('/management/kibana/settings/:setting?', {
   template: indexTemplate,
@@ -87,22 +59,28 @@ uiModules.get('apps/management').directive('kbnManagementAdvanced', function($ro
   return {
     restrict: 'E',
     link: function($scope) {
-      updateAdvancedSettings($scope, npStart.core.uiSettings, $route.current.params.setting || '');
-      npStart.core.uiSettings.getUpdate$().subscribe(() => {
-        updateAdvancedSettings(
-          $scope,
-          npStart.core.uiSettings,
-          $route.current.params.setting || ''
-        );
-      });
-
-      $scope.$on('$destroy', () => {
-        destroyAdvancedSettings();
-      });
-
-      $route.updateParams({ setting: null });
+      $scope.route = $route;
     },
   };
+});
+
+const AdvancedSettingsApp = ({ route }) => {
+  useEffectOnce(() => {
+    route.updateParams({ setting: null });
+  });
+
+  return (
+    <I18nContext>
+      <AdvancedSettings
+        query={route.current.params.setting || ''}
+        enableSaving={capabilities.get().advancedSettings.save}
+      />
+    </I18nContext>
+  );
+};
+
+uiModules.get('apps/management').directive('kbnManagementAdvancedReact', function(reactDirective) {
+  return reactDirective(AdvancedSettingsApp, [['route', { watchDepth: 'reference' }]]);
 });
 
 management.getSection('kibana').register('settings', {


### PR DESCRIPTION
## Summary

This PR solves couple of problems:
 - it 'reactifies' angular code with `reactDirective`
 - it moves the subscription logic to `AdvancedSettings` Component - thanks to that we don't need to use `componentwillreceiveprops` and we don't have to use reactDOM's `render` function on every settings' change
 - it solves the problem I mentioned in this PR: https://github.com/elastic/kibana/pull/54477 (the setting is being saved, the network request api/settings is run but the save button and cancel button stay in EUI - looks like UI components are not notified about the first change.). @mattkime fixed it via updating the internal state of the `Field` component, but I fear that it might surface again as the prop `settings` is not being synchronized with the state.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

