### PR TITLE
Table suggestion for runtime fields

### DIFF
--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/indexed_fields_table/components/table/table.tsx
@@ -14,7 +14,8 @@ import {
   EuiIconTip,
   EuiBasicTableColumn,
   EuiBadge,
-  EuiToolTip,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -131,6 +132,25 @@ const isExcludedAriaLabel = i18n.translate(
   }
 );
 
+const runtimeLabel = i18n.translate(
+  'indexPatternManagement.editIndexPattern.fields.table.runtimeLabel',
+  {
+    defaultMessage: 'Runtime',
+  }
+);
+
+const runtimeDescription = i18n.translate(
+  'indexPatternManagement.editIndexPattern.fields.table.runtimeDescription',
+  { defaultMessage: 'These fields are created a runtime' }
+);
+
+const isRuntimeAriaLabel = i18n.translate(
+  'indexPatternManagement.editIndexPattern.fields.table.isRuntimeAria',
+  {
+    defaultMessage: 'Is runtime',
+  }
+);
+
 const editLabel = i18n.translate('indexPatternManagement.editIndexPattern.fields.table.editLabel', {
   defaultMessage: 'Edit',
 });
@@ -178,11 +198,10 @@ export class Table extends PureComponent<IndexedFieldProps> {
     const { indexPattern } = this.props;
 
     return (
-      <span>
-        {field.name}
+      <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
+        <EuiFlexItem grow={false}>{field.name}</EuiFlexItem>
         {field.info && field.info.length ? (
-          <span>
-            &nbsp;
+          <EuiFlexItem grow={false}>
             <EuiIconTip
               type="questionInCircle"
               color="primary"
@@ -191,34 +210,24 @@ export class Table extends PureComponent<IndexedFieldProps> {
                 <div key={i}>{info}</div>
               ))}
             />
-          </span>
+          </EuiFlexItem>
         ) : null}
         {indexPattern.timeFieldName === name ? (
-          <span>
-            &nbsp;
+          <EuiFlexItem grow={false}>
             <EuiIconTip
               type="clock"
               color="primary"
               aria-label={primaryTimeAriaLabel}
               content={primaryTimeTooltip}
             />
-          </span>
-        ) : null}
-        {field.runtimeField && field.runtimeField.type ? (
-          <span>
-            &nbsp;<EuiBadge>{runtimeFieldBadge}</EuiBadge>
-          </span>
+          </EuiFlexItem>
         ) : null}
         {field.customLabel && field.customLabel !== field.name ? (
-          <div>
-            <EuiToolTip content={labelDescription}>
-              <EuiBadge iconType="flag" iconSide="left">
-                {field.customLabel}
-              </EuiBadge>
-            </EuiToolTip>
-          </div>
+          <EuiFlexItem grow={false}>
+            <EuiBadge color="hollow">label: {field.customLabel}</EuiBadge>
+          </EuiFlexItem>
         ) : null}
-      </span>
+      </EuiFlexGroup>
     );
   }
 
@@ -278,6 +287,14 @@ export class Table extends PureComponent<IndexedFieldProps> {
         name: formatHeader,
         dataType: 'string',
         sortable: true,
+      },
+      {
+        field: 'runtimeField',
+        name: runtimeLabel,
+        description: runtimeDescription,
+        dataType: 'boolean',
+        sortable: true,
+        render: (value: string) => this.renderBooleanTemplate(value, isRuntimeAriaLabel),
       },
       {
         field: 'searchable',


### PR DESCRIPTION
## Summary

Hey Matt, I tinkered with a few variations and have arrived at this arrangement. The layout of the icon + multiple badges felt less scalable when everything was 'on' in the first cell and the horizontal alignment was slightly off whenever the tooltip was added. To remedy that, here's what this PR is proposing:

- Have a single badge for the custom label
- Prefix it with 'label:' and avoid the tooltip altogether
- Make the runtime indicator its own column
- This has the additional benefit of making it sortable / easy to find runtime fields

<img width="1242" alt="Screen Shot 2021-02-10 at 7 38 23 PM" src="https://user-images.githubusercontent.com/446285/107594834-96150500-6bd8-11eb-8f40-338747185698.png">

If this looks good, feel free to merge and/or we can use it as a discussion point tomorrow.