### PR TITLE
Runtime field delete change confirm

### DIFF
--- a/src/plugins/index_pattern_field_editor/public/components/delete_field_modal.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/delete_field_modal.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState } from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiConfirmModal, EuiFieldText } from '@elastic/eui';
+import { EuiCallOut, EuiConfirmModal, EuiFieldText, EuiFormRow, EuiSpacer } from '@elastic/eui';
 
 const geti18nTexts = (fieldsToDelete?: string[]) => {
   let modalTitle = '';
@@ -19,7 +19,7 @@ const geti18nTexts = (fieldsToDelete?: string[]) => {
       ? i18n.translate(
           'indexPatternFieldEditor.deleteRuntimeField.confirmModal.deleteSingleTitle',
           {
-            defaultMessage: `Remove field '{name}'?`,
+            defaultMessage: `Remove {name} field?`,
             values: { name: fieldsToDelete[0] },
           }
         )
@@ -55,7 +55,7 @@ const geti18nTexts = (fieldsToDelete?: string[]) => {
     typeConfirm: i18n.translate(
       'indexPatternFieldEditor.deleteRuntimeField.confirmModal.typeConfirm',
       {
-        defaultMessage: "Type 'confirm' to continue:",
+        defaultMessage: "Type 'REMOVE' to continue",
       }
     ),
     warningRemovingFields: i18n.translate(
@@ -88,27 +88,28 @@ export function DeleteFieldModal({ fieldsToDelete, closeModal, confirmDelete }: 
       cancelButtonText={cancelButtonText}
       buttonColor="danger"
       confirmButtonText={confirmButtonText}
-      confirmButtonDisabled={confirmContent?.toLowerCase() !== 'confirm'}
+      confirmButtonDisabled={confirmContent?.toUpperCase() !== 'REMOVE'}
     >
-      <p>{i18nTexts.warningRemovingFields}</p>
-      {isMultiple && (
-        <>
-          <p>{warningMultipleFields}</p>
-          <ul>
-            {fieldsToDelete.map((fieldName) => (
-              <li key={fieldName}>{fieldName}</li>
-            ))}
-          </ul>
-        </>
-      )}
-      <>
-        <p>{i18nTexts.typeConfirm}</p>
+      <EuiCallOut color="warning" title={i18nTexts.warningRemovingFields} iconType="alert" size="s">
+        {isMultiple && (
+          <>
+            <p>{warningMultipleFields}</p>
+            <ul>
+              {fieldsToDelete.map((fieldName) => (
+                <li key={fieldName}>{fieldName}</li>
+              ))}
+            </ul>
+          </>
+        )}
+      </EuiCallOut>
+      <EuiSpacer />
+      <EuiFormRow label={i18nTexts.typeConfirm}>
         <EuiFieldText
           value={confirmContent}
           onChange={(e) => setConfirmContent(e.target.value)}
           data-test-subj="deleteModalConfirmText"
         />
-      </>
+      </EuiFormRow>
     </EuiConfirmModal>
   );
 }

--- a/src/plugins/index_pattern_field_editor/public/components/delete_field_modal.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/delete_field_modal.tsx
@@ -12,6 +12,7 @@ import { EuiCallOut, EuiConfirmModal, EuiFieldText, EuiFormRow, EuiSpacer } from
 
 const geti18nTexts = (fieldsToDelete?: string[]) => {
   let modalTitle = '';
+  let confirmButtonText = '';
   if (fieldsToDelete) {
     const isSingle = fieldsToDelete.length === 1;
 
@@ -19,27 +20,35 @@ const geti18nTexts = (fieldsToDelete?: string[]) => {
       ? i18n.translate(
           'indexPatternFieldEditor.deleteRuntimeField.confirmModal.deleteSingleTitle',
           {
-            defaultMessage: `Remove {name} field?`,
+            defaultMessage: `Remove field '{name}'`,
             values: { name: fieldsToDelete[0] },
           }
         )
       : i18n.translate(
           'indexPatternFieldEditor.deleteRuntimeField.confirmModal.deleteMultipleTitle',
           {
-            defaultMessage: `Remove {count} fields?`,
+            defaultMessage: `Remove {count} fields`,
             values: { count: fieldsToDelete.length },
+          }
+        );
+    confirmButtonText = isSingle
+      ? i18n.translate(
+          'indexPatternFieldEditor.deleteRuntimeField.confirmationModal.removeButtonLabel',
+          {
+            defaultMessage: `Remove field`,
+          }
+        )
+      : i18n.translate(
+          'indexPatternFieldEditor.deleteRuntimeField.confirmationModal.removeMultipleButtonLabel',
+          {
+            defaultMessage: `Remove fields`,
           }
         );
   }
 
   return {
     modalTitle,
-    confirmButtonText: i18n.translate(
-      'indexPatternFieldEditor.deleteRuntimeField.confirmationModal.removeButtonLabel',
-      {
-        defaultMessage: 'Remove',
-      }
-    ),
+    confirmButtonText,
     cancelButtonText: i18n.translate(
       'indexPatternFieldEditor.deleteRuntimeField.confirmationModal.cancelButtonLabel',
       {
@@ -55,7 +64,7 @@ const geti18nTexts = (fieldsToDelete?: string[]) => {
     typeConfirm: i18n.translate(
       'indexPatternFieldEditor.deleteRuntimeField.confirmModal.typeConfirm',
       {
-        defaultMessage: "Type 'REMOVE' to continue",
+        defaultMessage: "Type 'REMOVE' to confirm",
       }
     ),
     warningRemovingFields: i18n.translate(

--- a/src/plugins/index_pattern_field_editor/public/components/field_editor_flyout_content.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/field_editor_flyout_content.tsx
@@ -211,7 +211,7 @@ const FieldEditorFlyoutContentComponent = ({
 
   const modal = isModalVisible ? (
     <EuiConfirmModal
-      title={`Confirm changes to ${field?.name}`}
+      title={`Confirm changes to '${field?.name}'`}
       data-test-subj="runtimeFieldSaveConfirmModal"
       cancelButtonText={i18nTexts.cancelButtonText}
       confirmButtonText={i18nTexts.confirmButtonText}
@@ -249,7 +249,7 @@ const FieldEditorFlyoutContentComponent = ({
             {field ? (
               <FormattedMessage
                 id="indexPatternFieldEditor.editor.flyoutEditFieldTitle"
-                defaultMessage="Edit {fieldName} field"
+                defaultMessage="Edit field '{fieldName}'"
                 values={{
                   fieldName: field.name,
                 }}

--- a/src/plugins/index_pattern_field_editor/public/components/field_editor_flyout_content.tsx
+++ b/src/plugins/index_pattern_field_editor/public/components/field_editor_flyout_content.tsx
@@ -23,6 +23,7 @@ import {
   EuiText,
   EuiConfirmModal,
   EuiFieldText,
+  EuiFormRow,
 } from '@elastic/eui';
 
 import { DocLinksStart, CoreStart } from 'src/core/public';
@@ -65,7 +66,7 @@ const geti18nTexts = (field?: Field) => {
     typeConfirm: i18n.translate(
       'indexPatternFieldEditor.saveRuntimeField.confirmModal.typeConfirm',
       {
-        defaultMessage: "Type 'confirm' to continue:",
+        defaultMessage: "Type 'CHANGE' to continue:",
       }
     ),
   };
@@ -210,12 +211,11 @@ const FieldEditorFlyoutContentComponent = ({
 
   const modal = isModalVisible ? (
     <EuiConfirmModal
-      title={'Confirm save'}
+      title={`Confirm changes to ${field?.name}`}
       data-test-subj="runtimeFieldSaveConfirmModal"
       cancelButtonText={i18nTexts.cancelButtonText}
-      buttonColor="danger"
       confirmButtonText={i18nTexts.confirmButtonText}
-      confirmButtonDisabled={confirmContent?.toLowerCase() !== 'confirm'}
+      confirmButtonDisabled={confirmContent?.toUpperCase() !== 'CHANGE'}
       onCancel={() => {
         setIsModalVisible(false);
         setConfirmContent('');
@@ -225,52 +225,53 @@ const FieldEditorFlyoutContentComponent = ({
         onSave(data);
       }}
     >
-      <>
-        <p>{i18nTexts.warningChangingFields}</p>
-        <p>{i18nTexts.typeConfirm}</p>
+      <EuiCallOut
+        color="warning"
+        title={i18nTexts.warningChangingFields}
+        iconType="alert"
+        size="s"
+      />
+      <EuiSpacer />
+      <EuiFormRow label={i18nTexts.typeConfirm}>
         <EuiFieldText
           value={confirmContent}
           onChange={(e) => setConfirmContent(e.target.value)}
           data-test-subj="saveModalConfirmText"
         />
-      </>
+      </EuiFormRow>
     </EuiConfirmModal>
   ) : null;
   return (
     <>
       <EuiFlyoutHeader>
-        <EuiTitle size="m" data-test-subj="flyoutTitle">
-          {field ? (
-            <EuiText>
+        <EuiTitle data-test-subj="flyoutTitle">
+          <h2>
+            {field ? (
               <FormattedMessage
                 id="indexPatternFieldEditor.editor.flyoutEditFieldTitle"
-                defaultMessage="Edit {fieldName}"
+                defaultMessage="Edit {fieldName} field"
                 values={{
-                  fieldName: (
-                    <h2 id="fieldEditorTitle" style={{ display: 'inline' }}>
-                      {field.name}
-                    </h2>
-                  ),
+                  fieldName: field.name,
                 }}
               />
-            </EuiText>
-          ) : (
-            <h2>
+            ) : (
               <FormattedMessage
                 id="indexPatternFieldEditor.editor.flyoutDefaultTitle"
                 defaultMessage="Create field"
               />
-            </h2>
-          )}
+            )}
+          </h2>
         </EuiTitle>
-        <EuiText>
-          <FormattedMessage
-            id="indexPatternFieldEditor.editor.flyoutEditFieldSubtitle"
-            defaultMessage="Index pattern: {patternName}"
-            values={{
-              patternName: <i>{indexPattern.title}</i>,
-            }}
-          />
+        <EuiText color="subdued">
+          <p>
+            <FormattedMessage
+              id="indexPatternFieldEditor.editor.flyoutEditFieldSubtitle"
+              defaultMessage="Index pattern: {patternName}"
+              values={{
+                patternName: <i>{indexPattern.title}</i>,
+              }}
+            />
+          </p>
         </EuiText>
       </EuiFlyoutHeader>
 


### PR DESCRIPTION
## Summary

- Uses an `EuiCallout` to highlight the warning text in the modal
- Use an `EuiFormRow` to display a label for the text input (aligns with _Delete Space_ modal)
- Adjusts title copy (aligns with _Delete Space_ modal)
- Adds the word _field_ or _fields_ to the Remove button label to clarify what is being removed
- Makes the entire flyout header title text h2 and bold
- Makes the flyout header subtitle subdued


