### PR TITLE
Copy and design tweaks

### DIFF
--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/scripted_fields_table/components/header/header.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiText, EuiTitle, EuiLink } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiText, EuiLink, EuiIcon } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n/react';
 import { ScopedHistory } from 'kibana/public';
@@ -26,23 +26,14 @@ export const Header = withRouter(({ indexPatternId, history }: HeaderProps) => {
   return (
     <EuiFlexGroup alignItems="center">
       <EuiFlexItem>
-        <EuiTitle size="s">
-          <h3>
-            <FormattedMessage
-              id="indexPatternManagement.editIndexPattern.scriptedHeader"
-              defaultMessage="Scripted fields"
-            />
-          </h3>
-        </EuiTitle>
-        <EuiText>
+        <EuiText size="s">
           <p>
             <FormattedMessage
               id="indexPatternManagement.editIndexPattern.scriptedLabel"
-              defaultMessage="You can use scripted fields in visualizations and display them in your documents. However, you cannot search
-            scripted fields."
+              defaultMessage="Scripted fields can be used in visualizations and displayed in documents. However, they cannot be searched."
             />
-          </p>
-          <p>
+            <br />
+            <EuiIcon type="alert" color="warning" style={{ marginRight: '4px' }} />
             <FormattedMessage
               id="indexPatternManagement.editIndexPattern.deprecation"
               defaultMessage="Scripted fields are deprecated, {runtimeDocs}."

--- a/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/header.tsx
+++ b/src/plugins/index_pattern_management/public/components/edit_index_pattern/source_filters_table/components/header/header.tsx
@@ -13,15 +13,7 @@ import { FormattedMessage } from '@kbn/i18n/react';
 
 export const Header = () => (
   <>
-    <EuiTitle size="s">
-      <h3>
-        <FormattedMessage
-          id="indexPatternManagement.editIndexPattern.sourceHeader"
-          defaultMessage="Field filters"
-        />
-      </h3>
-    </EuiTitle>
-    <EuiText>
+    <EuiText size="s">
       <p>
         <FormattedMessage
           id="indexPatternManagement.editIndexPattern.sourceLabel"

--- a/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
+++ b/src/plugins/index_pattern_management/public/components/field_editor/components/scripting_call_outs/warning_call_out.tsx
@@ -8,7 +8,7 @@
 
 import React, { Fragment } from 'react';
 
-import { EuiCallOut, EuiLink, EuiSpacer } from '@elastic/eui';
+import { EuiCallOut, EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
 
 import { FormattedMessage } from '@kbn/i18n/react';
 
@@ -23,32 +23,34 @@ export const ScriptingWarningCallOut = ({ isVisible = false }: ScriptingWarningC
   const docLinks = useKibana<IndexPatternManagmentContext>().services.docLinks?.links;
   return isVisible ? (
     <Fragment>
-      <p>
-        <FormattedMessage
-          id="indexPatternManagement.warningCallOutLabel.callOutDetail"
-          defaultMessage="Please familiarize yourself with {scripFields} and with {scriptsInAggregation} before using scripted fields.
-          Scripted fields can be used to display and aggregate calculated values. As such, they can be very slow, and
-          if done incorrectly, can cause Kibana to be unusable."
-          values={{
-            scripFields: (
-              <EuiLink target="_blank" href={docLinks.scriptedFields.scriptFields}>
-                <FormattedMessage
-                  id="indexPatternManagement.warningCallOutLabel.scripFieldsLink"
-                  defaultMessage="scripted fields"
-                />
-              </EuiLink>
-            ),
-            scriptsInAggregation: (
-              <EuiLink target="_blank" href={docLinks.scriptedFields.scriptAggs}>
-                <FormattedMessage
-                  id="indexPatternManagement.warningCallOutLabel.scriptsInAggregationLink"
-                  defaultMessage="scripts in aggregations"
-                />
-              </EuiLink>
-            ),
-          }}
-        />
-      </p>
+      <EuiText size="s">
+        <p>
+          <FormattedMessage
+            id="indexPatternManagement.warningCallOutLabel.callOutDetail"
+            defaultMessage="Please familiarize yourself with {scripFields} and {scriptsInAggregation} before using this feature.
+            Scripted fields can be used to display and aggregate calculated values. As such, they can be very slow and,
+            if done incorrectly, can cause Kibana to become unusable."
+            values={{
+              scripFields: (
+                <EuiLink target="_blank" href={docLinks.scriptedFields.scriptFields}>
+                  <FormattedMessage
+                    id="indexPatternManagement.warningCallOutLabel.scripFieldsLink"
+                    defaultMessage="scripted fields"
+                  />
+                </EuiLink>
+              ),
+              scriptsInAggregation: (
+                <EuiLink target="_blank" href={docLinks.scriptedFields.scriptAggs}>
+                  <FormattedMessage
+                    id="indexPatternManagement.warningCallOutLabel.scriptsInAggregationLink"
+                    defaultMessage="scripts in aggregations"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        </p>
+      </EuiText>
       <EuiSpacer size="m" />
       <EuiCallOut
         color="warning"
@@ -61,20 +63,24 @@ export const ScriptingWarningCallOut = ({ isVisible = false }: ScriptingWarningC
           />
         }
       >
-        <FormattedMessage
-          id="indexPatternManagement.scriptedFieldsDeprecatedBody"
-          defaultMessage="{runtimeDocs}, which support Painless scripts and provide greater flexibility."
-          values={{
-            runtimeDocs: (
-              <EuiLink target="_blank" href={docLinks.runtimeFields.overview}>
-                <FormattedMessage
-                  id="indexPatternManagement.warningCallOutLabel.runtimeLink"
-                  defaultMessage="Use runtime fields instead"
-                />
-              </EuiLink>
-            ),
-          }}
-        />
+        <EuiText size="s">
+          <p>
+            <FormattedMessage
+              id="indexPatternManagement.scriptedFieldsDeprecatedBody"
+              defaultMessage="For greater flexibility and Painless script support, {runtimeDocs}."
+              values={{
+                runtimeDocs: (
+                  <EuiLink target="_blank" href={docLinks.runtimeFields.overview}>
+                    <FormattedMessage
+                      id="indexPatternManagement.warningCallOutLabel.runtimeLink"
+                      defaultMessage="use runtime fields"
+                    />
+                  </EuiLink>
+                ),
+              }}
+            />
+          </p>
+        </EuiText>
       </EuiCallOut>
       <EuiSpacer size="m" />
     </Fragment>


### PR DESCRIPTION
## Summary

Nothing major here, just some copy, typography, and minor design tweaks:
- Adjusts wording in a couple spots
- Change to smaller font size on descriptive text
- Add `alert` icon before deprecation sentence
- Remove some vertical spacing between paragraphs
- Remove the `EuiTitle` usage; it felt redundant to the tab title and made the copy more challenging to write (redundancy of 'Scripted fields...')
- Use `EuiText` on 'Create scripted field' page