### PR TITLE
Add search source support for searching hidden indices

### DIFF
--- a/src/plugins/data/common/search/search_source/fetch/get_search_params.test.ts
+++ b/src/plugins/data/common/search/search_source/fetch/get_search_params.test.ts
@@ -9,6 +9,7 @@
 import { UI_SETTINGS } from '../../../constants';
 import { GetConfigFn } from '../../../types';
 import { getSearchParams, getSearchParamsFromRequest } from './get_search_params';
+import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 
 function getConfigStub(config: any = {}): GetConfigFn {
   return (key) => config[key];
@@ -45,5 +46,49 @@ describe('getSearchParams', () => {
     expect(searchParams.body).toStrictEqual({
       query: 123,
     });
+  });
+
+  test('sets expand_wildcards=all if data view has allowHidden=true', () => {
+    const getConfig = getConfigStub({
+      [UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE]: 'custom',
+      [UI_SETTINGS.COURIER_CUSTOM_REQUEST_PREFERENCE]: 'aaa',
+    });
+    const index = {
+      ...dataViewMock,
+      allowHidden: true,
+    };
+    const searchParams = getSearchParamsFromRequest(
+      {
+        index,
+        body: {
+          query: 123,
+          track_total_hits: true,
+        },
+      },
+      { getConfig }
+    );
+    expect(searchParams).toHaveProperty('expand_wildcards', 'all');
+  });
+
+  test('does not set expand_wildcards if data view has allowHidden=false', () => {
+    const getConfig = getConfigStub({
+      [UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE]: 'custom',
+      [UI_SETTINGS.COURIER_CUSTOM_REQUEST_PREFERENCE]: 'aaa',
+    });
+    const index = {
+      ...dataViewMock,
+      allowHidden: false,
+    };
+    const searchParams = getSearchParamsFromRequest(
+      {
+        index,
+        body: {
+          query: 123,
+          track_total_hits: true,
+        },
+      },
+      { getConfig }
+    );
+    expect(searchParams).not.toHaveProperty('expand_wildcards', 'all');
   });
 });

--- a/src/plugins/data/common/search/search_source/fetch/get_search_params.test.ts
+++ b/src/plugins/data/common/search/search_source/fetch/get_search_params.test.ts
@@ -9,7 +9,7 @@
 import { UI_SETTINGS } from '../../../constants';
 import { GetConfigFn } from '../../../types';
 import { getSearchParams, getSearchParamsFromRequest } from './get_search_params';
-import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_views/data_view.stub';
 
 function getConfigStub(config: any = {}): GetConfigFn {
   return (key) => config[key];
@@ -53,10 +53,11 @@ describe('getSearchParams', () => {
       [UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE]: 'custom',
       [UI_SETTINGS.COURIER_CUSTOM_REQUEST_PREFERENCE]: 'aaa',
     });
-    const index = {
-      ...dataViewMock,
-      allowHidden: true,
-    };
+    const index = createStubDataView({
+      spec: {
+        allowHidden: true,
+      },
+    });
     const searchParams = getSearchParamsFromRequest(
       {
         index,
@@ -75,10 +76,11 @@ describe('getSearchParams', () => {
       [UI_SETTINGS.COURIER_SET_REQUEST_PREFERENCE]: 'custom',
       [UI_SETTINGS.COURIER_CUSTOM_REQUEST_PREFERENCE]: 'aaa',
     });
-    const index = {
-      ...dataViewMock,
-      allowHidden: false,
-    };
+    const index = createStubDataView({
+      spec: {
+        allowHidden: false,
+      },
+    });
     const searchParams = getSearchParamsFromRequest(
       {
         index,

--- a/src/plugins/data/common/search/search_source/fetch/get_search_params.ts
+++ b/src/plugins/data/common/search/search_source/fetch/get_search_params.ts
@@ -44,6 +44,7 @@ export function getSearchParamsFromRequest(
     body,
     // @ts-expect-error `track_total_hits` not allowed at top level for `typesWithBodyKey`
     track_total_hits,
+    ...(searchRequest.index?.allowHidden && { expand_wildcards: 'all' }),
     ...searchParams,
   };
 }


### PR DESCRIPTION
## Summary

Add search source support for searching hidden indices.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
