### PR TITLE
Ensure we're using the data view time field for the `sort` param too

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
@@ -112,18 +112,17 @@ export function updateSearchSource(
   alertLimit?: number
 ): { searchSource: ISearchSource; filterToExcludeHitsFromPreviousRun: Filter | null } {
   const isGroupAgg = isGroupAggregation(params.termField);
-  const timeFieldName = params.timeField || index.timeFieldName;
+  const timeField = index.getTimeField();
 
-  if (!timeFieldName) {
-    throw new Error('Invalid data view without timeFieldName.');
+  if (!timeField) {
+    throw new Error(`Data view with ID ${index.id} no longer contains a time field.`);
   }
 
   searchSource.setField('size', isGroupAgg ? 0 : params.size);
 
-  const field = index.getTimeField();
   const filters = [
     buildRangeFilter(
-      field!,
+      timeField,
       { lte: dateEnd, gte: dateStart, format: 'strict_date_optional_time' },
       index
     ),
@@ -135,7 +134,7 @@ export function updateSearchSource(
       // add additional filter for documents with a timestamp greater than
       // the timestamp of the previous run, so that those documents are not counted twice
       filterToExcludeHitsFromPreviousRun = buildRangeFilter(
-        field!,
+        timeField,
         { gt: latestTimestamp, format: 'strict_date_optional_time' },
         index
       );
@@ -150,7 +149,7 @@ export function updateSearchSource(
   searchSourceChild.setField('filter', filters as Filter[]);
   searchSourceChild.setField('sort', [
     {
-      [timeFieldName]: {
+      [timeField.name]: {
         order: SortDirection.desc,
         format: 'strict_date_optional_time||epoch_millis',
       },


### PR DESCRIPTION
## Summary

This PR updates the search source alert time field fix to also use the data view time field for the `sort` param, as well as adding a new error if the data view no longer has a time field.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)